### PR TITLE
Fix error happening when playing more than one sfx at once

### DIFF
--- a/src/SoundEngine.cpp
+++ b/src/SoundEngine.cpp
@@ -66,7 +66,7 @@ struct SoundFinishedCallbacks {
     static void remove_sound_from_map(int channel) {
         if (auto sound_it = channel_map.find(channel);
             sound_it != channel_map.end()) {
-            Sound sound = sound_it->first;
+            Sound sound = sound_it->second;
             finish_callback(sound);
             channel_map.erase(sound_it);
             active_sounds.erase(sound);


### PR DESCRIPTION
Mistyped "second". Wasted around 3 hours of my life fixing it. Yay.

Sounds were removing their channel from the active_sounds map instead of their handle, which was resulting in extra weird behaviour (In my case, removing the music sound from the map entirely and replacing it with the last sound effect played.)